### PR TITLE
Attempt to fix #185 - Set overrides items

### DIFF
--- a/benchmark/go.mod
+++ b/benchmark/go.mod
@@ -13,5 +13,3 @@ require (
 	github.com/pquerna/ffjson v0.0.0-20181028064349-e517b90714f7
 	github.com/ugorji/go v1.1.4
 )
-
-go 1.13

--- a/benchmark/go.mod
+++ b/benchmark/go.mod
@@ -13,3 +13,5 @@ require (
 	github.com/pquerna/ffjson v0.0.0-20181028064349-e517b90714f7
 	github.com/ugorji/go v1.1.4
 )
+
+go 1.13

--- a/parser.go
+++ b/parser.go
@@ -588,15 +588,17 @@ func createInsertComponent(keys []string, setValue []byte, comma, object bool) [
 	if comma {
 		buffer.WriteString(",")
 	}
-	if isIndex {
+	if isIndex && !comma {
 		buffer.WriteString("[")
 	} else {
 		if object {
 			buffer.WriteString("{")
 		}
-		buffer.WriteString("\"")
-		buffer.WriteString(keys[0])
-		buffer.WriteString("\":")
+		if !isIndex {
+			buffer.WriteString("\"")
+			buffer.WriteString(keys[0])
+			buffer.WriteString("\":")
+		}
 	}
 
 	for i := 1; i < len(keys); i++ {
@@ -616,7 +618,7 @@ func createInsertComponent(keys []string, setValue []byte, comma, object bool) [
 			buffer.WriteString("}")
 		}
 	}
-	if isIndex {
+	if isIndex && !comma {
 		buffer.WriteString("]")
 	}
 	if object && !isIndex {
@@ -765,7 +767,9 @@ func Set(data []byte, setValue []byte, keys ...string) (value []byte, err error)
 		depthOffset := endOffset
 		if depth != 0 {
 			// if subpath is a non-empty object, add to it
-			if data[startOffset] == '{' && data[startOffset+1+nextToken(data[startOffset+1:])] != '}' {
+			// or if subpath is a non-empty array, add to it
+			if (data[startOffset] == '{' && data[startOffset+1+nextToken(data[startOffset+1:])] != '}') ||
+				(data[startOffset] == '[' && data[startOffset+1+nextToken(data[startOffset+1:])] == '{') && keys[depth:][0][0] == 91 {
 				depthOffset--
 				startOffset = depthOffset
 				// otherwise, over-write it with a new object

--- a/parser_test.go
+++ b/parser_test.go
@@ -380,6 +380,14 @@ var setTests = []SetTest{
 		isFound: true,
 		data:    `{"top":["one", "two", "value"]}`,
 	},
+	{
+		desc:    "set unknown key (simple object within nested array)",
+		json:    `{"test":{"key":[{"innerKey":"innerKeyValue", "innerKey2":"innerKeyValue2"}]}}`,
+		isFound: true,
+		path:    []string{"test", "key", "[1]", "newInnerKey"},
+		setData: `"new object"`,
+		data:    `{"test":{"key":[{"innerKey":"innerKeyValue", "innerKey2":"innerKeyValue2"},{"newInnerKey":"new object"}]}}`,
+	},
 }
 
 var getTests = []GetTest{


### PR DESCRIPTION
If you try to set an unknown key, simple object within a nested array, passing in the index, the parser will override the object and does not take into account the given index [1].

With current parser version, given this json as input:
```json
{
    "test": {
        "key": [
            {
                "innerKey": "innerKeyValue",
                "innerKey2": "innerKeyValue2"
            }
        ]
    }
}
```
and following path to set an unknown key: `"test", "key", "[1]", "newInnerKey"` with data `"new object"`, the output would be:
```json
{
    "test": {
        "key": [
            {
                "newInnerKey": "new object"
            }
        ]
    }
}
```
which I think it is wrong, since it overrides what index [0] had but the above path wanted to insert the object in index [1] instead.

With the changes done in this PR, given the same json input, path and data, the output would be:
```json
{
    "test": {
        "key": [
            {
                "innerKey": "innerKeyValue",
                "innerKey2": "innerKeyValue2"
            },
            {
                "newInnerKey": "new object"
            }
        ]
    }
}
```
the above result would be correct since we are setting a new object within the existing array in a different index [1], keeping what the array already had in previous index [0].

Added also a test to cover this scenario. All tests pass.

This appears to fix [#185](https://github.com/buger/jsonparser/issues/185) and includes a test for it.

**Description**: What this PR does

**Benchmark before change**:
Benchmarks are broken.